### PR TITLE
Allow running without a Google Books API key

### DIFF
--- a/src/booksearch.py
+++ b/src/booksearch.py
@@ -177,9 +177,17 @@ def _get_image_url(sess, item):
 
 
 def lookup_google_books(*, sess=requests.Session(), api_key, search_query):
+    params = [
+        ("q", search_query),
+        ("country", "UK"),
+    ]
+
+    if api_key is not None:
+        params.append(("key", api_key))
+
     resp = sess.get(
         "https://www.googleapis.com/books/v1/volumes",
-        params=[("q", search_query), ("key", api_key), ("country", "UK")],
+        params=params,
         headers={"User-Agent": "alexwlchan's book tracker"},
     )
     resp.raise_for_status()

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,7 @@ basedir = pathlib.Path(__file__).parent.resolve()
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or "you-will-never-guess"
 
-    GOOGLE_BOOKS_API_KEY = os.environ.get("GOOGLE_BOOKS_API_KEY", "<API_KEY>")
+    GOOGLE_BOOKS_API_KEY = os.environ.get("GOOGLE_BOOKS_API_KEY")
 
     try:
         SQLALCHEMY_DATABASE_URI = os.environ["DATABASE_URL"]

--- a/tests/cassettes/test_can_make_api_request.json
+++ b/tests/cassettes/test_can_make_api_request.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=fish&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=fish&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=fish&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=fish&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_combines_authors_into_string.json
+++ b/tests/cassettes/test_combines_authors_into_string.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=2lBxWxua9H0C&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=2lBxWxua9H0C&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=2lBxWxua9H0C&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=2lBxWxua9H0C&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_copes_with_missing_authors.json
+++ b/tests/cassettes/test_copes_with_missing_authors.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=H-gTlLLybXAC&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=H-gTlLLybXAC&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=H-gTlLLybXAC&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=H-gTlLLybXAC&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_gets_identifiers_correctly[0K4RCTFXFTkC-expected_identifiers0].json
+++ b/tests/cassettes/test_gets_identifiers_correctly[0K4RCTFXFTkC-expected_identifiers0].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=0K4RCTFXFTkC&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=0K4RCTFXFTkC&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=0K4RCTFXFTkC&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=0K4RCTFXFTkC&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_gets_identifiers_correctly[XaKdAQAACAAJ-expected_identifiers1].json
+++ b/tests/cassettes/test_gets_identifiers_correctly[XaKdAQAACAAJ-expected_identifiers1].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=XaKdAQAACAAJ&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=XaKdAQAACAAJ&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=XaKdAQAACAAJ&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=XaKdAQAACAAJ&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_gets_image_url_correctly[DJN_72oR4gkC-http___books.google.com_books_content?id=DJN_72oR4gkC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api].json
+++ b/tests/cassettes/test_gets_image_url_correctly[DJN_72oR4gkC-http___books.google.com_books_content?id=DJN_72oR4gkC&printsec=frontcover&img=1&zoom=1&edge=curl&source=gbs_api].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=DJN_72oR4gkC&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=DJN_72oR4gkC&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=DJN_72oR4gkC&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=DJN_72oR4gkC&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_gets_image_url_correctly[chcnvwEACAAJ-].json
+++ b/tests/cassettes/test_gets_image_url_correctly[chcnvwEACAAJ-].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=chcnvwEACAAJ&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=chcnvwEACAAJ&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=chcnvwEACAAJ&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=chcnvwEACAAJ&country=UK&key=<API_KEY>"
       }
     },
     {

--- a/tests/cassettes/test_gets_year_correctly[4B4eHLgO4iEC-].json
+++ b/tests/cassettes/test_gets_year_correctly[4B4eHLgO4iEC-].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=4B4eHLgO4iEC&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=4B4eHLgO4iEC&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=4B4eHLgO4iEC&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=4B4eHLgO4iEC&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_gets_year_correctly[aRYR1tnmKpEC-1990].json
+++ b/tests/cassettes/test_gets_year_correctly[aRYR1tnmKpEC-1990].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=aRYR1tnmKpEC&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=aRYR1tnmKpEC&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=aRYR1tnmKpEC&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=aRYR1tnmKpEC&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_gets_year_correctly[sVbeAAAACAAJ-2003].json
+++ b/tests/cassettes/test_gets_year_correctly[sVbeAAAACAAJ-2003].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=sVbeAAAACAAJ&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=sVbeAAAACAAJ&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=sVbeAAAACAAJ&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=sVbeAAAACAAJ&country=UK&key=<API_KEY>"
       }
     },
     {

--- a/tests/cassettes/test_gets_year_correctly[tAMGoQEACAAJ-2014].json
+++ b/tests/cassettes/test_gets_year_correctly[tAMGoQEACAAJ-2014].json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=tAMGoQEACAAJ&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=tAMGoQEACAAJ&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=tAMGoQEACAAJ&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=tAMGoQEACAAJ&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_handles_encoding_correctly.json
+++ b/tests/cassettes/test_handles_encoding_correctly.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=yU_hAuvMTQUC&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=yU_hAuvMTQUC&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=yU_hAuvMTQUC&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=yU_hAuvMTQUC&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_handles_no_identifiers.json
+++ b/tests/cassettes/test_handles_no_identifiers.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=PediaPress+Foo+Fighters&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=PediaPress+Foo+Fighters&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=PediaPress+Foo+Fighters&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=PediaPress+Foo+Fighters&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_renders_curly_quote_in_results.json
+++ b/tests/cassettes/test_renders_curly_quote_in_results.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=9780571311873&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=9780571311873&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=9780571311873&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=9780571311873&country=UK&key=<API_KEY>"
       }
     }
   ],

--- a/tests/cassettes/test_search_with_no_results_is_empty.json
+++ b/tests/cassettes/test_search_with_no_results_is_empty.json
@@ -22,7 +22,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://www.googleapis.com/books/v1/volumes?q=F4744518-1E7B-44F8-9AA1-D837FCD2E679&key=<API_KEY>&country=UK"
+        "uri": "https://www.googleapis.com/books/v1/volumes?q=F4744518-1E7B-44F8-9AA1-D837FCD2E679&country=UK&key=<API_KEY>"
       },
       "response": {
         "body": {
@@ -75,7 +75,7 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.googleapis.com/books/v1/volumes?q=F4744518-1E7B-44F8-9AA1-D837FCD2E679&key=<API_KEY>&country=UK"
+        "url": "https://www.googleapis.com/books/v1/volumes?q=F4744518-1E7B-44F8-9AA1-D837FCD2E679&country=UK&key=<API_KEY>"
       }
     }
   ],


### PR DESCRIPTION
This reduces the rate limits significantly and isn't suitable for running in production (probably), but makes it easier to run a local instance for dev testing.

Closes #17.