### PR TITLE
Make the "edit review" route consistent with "edit plan"/"reading"

### DIFF
--- a/src/forms.py
+++ b/src/forms.py
@@ -5,7 +5,6 @@ import datetime
 from flask_wtf import FlaskForm
 from wtforms import (
     DateField,
-    IntegerField,
     StringField,
     PasswordField,
     BooleanField,
@@ -49,7 +48,7 @@ class ReviewForm(ReviewFormMixin, BookFormMixin, FlaskForm):
 
 
 class EditReviewForm(ReviewFormMixin, FlaskForm):
-    review_id = IntegerField("id", validators=[DataRequired()])
+    pass
 
 
 class ReadingFormMixin:

--- a/src/routes.py
+++ b/src/routes.py
@@ -266,18 +266,16 @@ def add_plan():
     return redirect(url_for("list_plans") + f"#plan-{plan.id}")
 
 
-@app.route("/edit-review", methods=["POST"])
+@app.route("/edit-review/<review_id>", methods=["POST"])
 @must_be_primary_user
-def edit_review():
+def edit_review(review_id):
     user = User.query.get(1)
     edit_form = EditReviewForm()
 
     if not edit_form.validate_on_submit():
         abort(400)
 
-    review = Review.query.filter_by(
-        id=edit_form.review_id.data, user_id=user.id
-    ).first_or_404()
+    review = Review.query.filter_by(id=review_id, user_id=user.id).first_or_404()
 
     review.review_text = edit_form.review_text.data
     review.date_read = edit_form.date_read.data

--- a/src/templates/_review.html
+++ b/src/templates/_review.html
@@ -64,13 +64,11 @@
     </div>
 
     <form
-      action="{{ url_for('edit_review') }}"
+      action="{{ url_for('edit_review', review_id=review.id) }}"
       method="POST"
       class="hidden book-edit-form"
     >
       {{ edit_form.hidden_tag() }}
-
-      {{ edit_form.review_id(value=review.id, type="hidden") }}
 
       <p>
         {{ edit_form.review_text.label }}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -19,7 +19,7 @@ from src.models import Plan, Reading, Review
         "/delete-review/1",
         "/edit-plan/1",
         "/edit-reading/1",
-        "/edit-review",
+        "/edit-review/1",
         "/mark_as_read/1",
         "/mark_plan_as_read/1",
         "/move_plan_to_reading/1",
@@ -30,9 +30,7 @@ def test_cannot_post_to_route_if_not_logged_in(client, session, user, path):
     assert resp.status_code == 401
 
 
-@pytest.mark.parametrize(
-    "path", ["/add-plan", "/add-reading", "/add-review", "/edit-review"],
-)
+@pytest.mark.parametrize("path", ["/add-plan", "/add-reading", "/add-review"])
 def test_invalid_form_data_is_error(client, session, logged_in_user, path):
     resp = client.post(path, data={})
     assert resp.status_code == 400
@@ -41,7 +39,7 @@ def test_invalid_form_data_is_error(client, session, logged_in_user, path):
 def test_cannot_edit_review_with_invalid_form_data(
     client, session, logged_in_user, review
 ):
-    resp = client.post("/edit-review", data={})
+    resp = client.post("/edit-review/1", data={})
     assert resp.status_code == 400
 
 
@@ -82,10 +80,9 @@ class TestEditRoutes:
         csrf_token = helpers.get_csrf_token(client, path=f"/reviews/{review.id}")
 
         resp = client.post(
-            "/edit-review",
+            f"/edit-review/{review.id}",
             data={
                 "csrf_token": csrf_token,
-                "review_id": review.id,
                 "review_text": new_review_text,
                 "date_read": new_date_read.isoformat(),
                 "did_not_finish": new_did_not_finish,
@@ -108,7 +105,7 @@ class TestEditRoutes:
         csrf_token = helpers.get_csrf_token(client, path=f"/reviews/{review.id}")
 
         resp = client.post(
-            "/edit-review",
+            f"/edit-review/{review.id + 1}",
             data={
                 "csrf_token": csrf_token,
                 "review_id": review.id + 1,


### PR DESCRIPTION
Plan and reading take the ID as a path parameter, whereas review took it as a form option.  This inconsistency tripped me up at least twice. Make it not be so!